### PR TITLE
Bump dependencies and add missing aeron and async-function-execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,13 @@ ENDIF ()
 
 FIND_PACKAGE(nlohmann_json 3.10.5 REQUIRED)
 FIND_PACKAGE(fleet-protocol-interface 2.0.0 REQUIRED)
-FIND_PACKAGE(fleet-protocol-cxx-helpers-static 1.1.1 REQUIRED)
+FIND_PACKAGE(aeron 1.48.6 REQUIRED)
+FIND_PACKAGE(async-function-execution-shared 1.0.0 REQUIRED)
+FIND_PACKAGE(fleet-protocol-cxx-helpers-static 1.2.0 REQUIRED)
 
 IF (FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER)
 
-    FIND_PACKAGE(fleet-http-client-shared 1.5.0 REQUIRED)
+    FIND_PACKAGE(fleet-http-client-shared 2.0.1 REQUIRED)
     ### fleet-http-client dependencies
     FIND_PACKAGE(Boost CONFIG REQUIRED)
     FIND_PACKAGE(ZLIB REQUIRED)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,11 +1,13 @@
 SET(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH FALSE)
 
 BA_PACKAGE_LIBRARY(nlohmann-json            v3.10.5 NO_DEBUG ON)
-BA_PACKAGE_LIBRARY(fleet-protocol-cpp       v1.1.1)
+BA_PACKAGE_LIBRARY(fleet-protocol-cpp       v1.2.0)
+BA_PACKAGE_LIBRARY(async-function-execution v1.0.0)
+BA_PACKAGE_LIBRARY(aeron                   v1.48.6)
 BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 NO_DEBUG ON)
 
 IF (FLEET_PROTOCOL_BUILD_EXTERNAL_SERVER)
-    BA_PACKAGE_LIBRARY(fleet-http-client-shared             v1.5.0)
+    BA_PACKAGE_LIBRARY(fleet-http-client-shared             v2.0.1)
     BA_PACKAGE_LIBRARY(boost         v1.86.0)
     BA_PACKAGE_LIBRARY(cpprestsdk    v2.10.20)
     BA_PACKAGE_LIBRARY(zlib                                 v1.2.11)


### PR DESCRIPTION
- Bump `fleet-protocol-cpp` v1.1.1 → v1.2.0
- Bump `fleet-http-client-shared` v1.5.0 → v2.0.1
- Bump `fleet-protocol-cxx-helpers-static` 1.1.1 → 1.2.0
- Add missing `async-function-execution` v1.0.0 (required by fleet-protocol-cxx-helpers-static v1.2.0)
- Add missing `aeron` v1.48.6 (required by async-function-execution v1.0.0)

Build verified locally.